### PR TITLE
GHES support. Allow projects outside github.com

### DIFF
--- a/src/add-to-project.ts
+++ b/src/add-to-project.ts
@@ -4,7 +4,7 @@ import * as github from '@actions/github'
 // TODO: Ensure this (and the Octokit client) works for non-github.com URLs, as well.
 // https://github.com/orgs|users/<ownerName>/projects/<projectNumber>
 const urlParse =
-  /^(?:https:\/\/)?github\.com\/(?<ownerType>orgs|users)\/(?<ownerName>[^/]+)\/projects\/(?<projectNumber>\d+)/
+  /^(?:https:\/\/)?[^/]+\/(?<ownerType>orgs|users)\/(?<ownerName>[^/]+)\/projects\/(?<projectNumber>\d+)/
 
 interface ProjectNodeIDResponse {
   organization?: {


### PR DESCRIPTION
I'm trying to use this action on GHES, and I see there's a strict URL match for github.com projects though the domain isn't use thereafter.