### PR TITLE
set @types/node version to latest v16 release

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set Node.js 12.x
+      - name: Set Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 16.x
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@github/prettier-config": "^0.0.6",
         "@types/jest": "^27.5.0",
-        "@types/node": "16.11.68",
+        "@types/node": "16.18.26",
         "@typescript-eslint/parser": "^5.59.2",
         "@vercel/ncc": "^0.36.1",
         "concurrently": "^8.0.1",
@@ -1435,9 +1435,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
+      "version": "16.18.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.26.tgz",
+      "integrity": "sha512-pCNBzNQqCXE4A6FWDmrn/o1Qu+qBf8tnorBlNoPNSBQJF+jXzvTKNI/aMiE+hGJbK5sDAD65g7OS/YwSHIEJdw==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -8419,9 +8419,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
+      "version": "16.18.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.26.tgz",
+      "integrity": "sha512-pCNBzNQqCXE4A6FWDmrn/o1Qu+qBf8tnorBlNoPNSBQJF+jXzvTKNI/aMiE+hGJbK5sDAD65g7OS/YwSHIEJdw==",
       "dev": true
     },
     "@types/prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@github/prettier-config": "^0.0.6",
         "@types/jest": "^27.5.0",
-        "@types/node": "~16.18.25",
+        "@types/node": "16.11.68",
         "@typescript-eslint/parser": "^5.59.2",
         "@vercel/ncc": "^0.36.1",
         "concurrently": "^8.0.1",
@@ -1435,9 +1435,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
-      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
+      "version": "16.11.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -8419,9 +8419,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
-      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
+      "version": "16.11.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@github/prettier-config": "^0.0.6",
     "@types/jest": "^27.5.0",
-    "@types/node": "~16.18.25",
+    "@types/node": "16.11.68",
     "@typescript-eslint/parser": "^5.59.2",
     "@vercel/ncc": "^0.36.1",
     "concurrently": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@github/prettier-config": "^0.0.6",
     "@types/jest": "^27.5.0",
-    "@types/node": "16.11.68",
+    "@types/node": "16.18.26",
     "@typescript-eslint/parser": "^5.59.2",
     "@vercel/ncc": "^0.36.1",
     "concurrently": "^8.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "outDir": "./lib" /* Redirect output structure to the directory. */,
     "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "lib": ["ES2015"]
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
Related to https://github.com/actions/add-to-project/pull/372

This repository should only upgrade the `@types/node` package based on the versions supported by Actions. For now, let's leave this at `node16` which is the version documented here:

https://github.com/actions/add-to-project/blob/23e138997104dba93ffb22a4b16bb9baa911cef4/action.yml#L19-L21