### PR TITLE
Improve output of `check-dist` workflow

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -45,8 +45,9 @@ jobs:
         run: |
           CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE")
           if [ -n "$CHANGED_FILES" ]; then
-            echo "Detected uncommitted changes after build (see diff output below)." >&2
+            echo "❗️ Detected uncommitted changes after build (see diff output below)." >&2
             echo "This indicates that the dist/ directory is out of sync with the checked-in index.js." >&2
+            echo "⭐️ If the changes below are expected, run 'npm run build:compile && npm run build:package' and commit the output files." >&2
             # Run `git diff` for each line/file in $CHANGED_FILES:
             echo "$CHANGED_FILES" | xargs -I {} git diff --ignore-space-at-eol --text -- {}
             exit 1

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE")
+          # Get a list of files that are different between the checked-in dist/ directory and the generated dist/ directory,
+          # then trim the list to remove any leading or trailing whitespace.
+          CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           if [ -n "$CHANGED_FILES" ]; then
             echo "\n❗️ Detected uncommitted changes after build (see diff output below)." >&2
             echo "This indicates that the dist/ directory is out of sync with the checked-in index.js.\n" >&2

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -15,6 +15,11 @@ on:
     paths-ignore:
       - '**.md'
 
+env:
+  # A pipe-separated array of files to ignore when comparing the expected and actual dist/ directories,
+  # which are used as a regular expression filter in the `grep` command.
+  FILES_TO_IGNORE: 'index.js.map|sourcemap-register.js'
+
 jobs:
   check-dist:
     runs-on: ubuntu-latest
@@ -38,9 +43,12 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
-            echo "Detected uncommitted changes after build.  See status below:"
-            git diff
+          CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE")
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "Detected uncommitted changes after build (see diff output below)." >&2
+            echo "This indicates that the dist/ directory is out of sync with the checked-in index.js." >&2
+            # Run `git diff` for each line/file in $CHANGED_FILES:
+            echo "$CHANGED_FILES" | xargs -I {} git diff --ignore-space-at-eol --text -- {}
             exit 1
           fi
         id: diff

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -48,7 +48,7 @@ jobs:
           CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           if [ -n "$CHANGED_FILES" ]; then
             echo "❗️ Detected uncommitted changes after build (see diff output below)." >&2
-            echo "This indicates that the dist/ directory is out of sync with the checked-in index.js.\n" >&2
+            echo "This indicates that the dist/ directory is out of sync with the checked-in index.js." >&2
             echo "⭐️ If the changes below are expected, run 'npm run build:compile && npm run build:package' and commit the output files." >&2
             # Run `git diff` for each line/file in $CHANGED_FILES:
             echo "$CHANGED_FILES" | xargs -I {} git diff --ignore-space-at-eol --text -- {}

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -47,12 +47,14 @@ jobs:
           # then trim the list to remove any leading or trailing whitespace.
           CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           if [ -n "$CHANGED_FILES" ]; then
-            echo "\n❗️ Detected uncommitted changes after build (see diff output below)." >&2
+            echo "❗️ Detected uncommitted changes after build (see diff output below)." >&2
             echo "This indicates that the dist/ directory is out of sync with the checked-in index.js.\n" >&2
-            echo "⭐️ If the changes below are expected, run 'npm run build:compile && npm run build:package' and commit the output files.\n" >&2
+            echo "⭐️ If the changes below are expected, run 'npm run build:compile && npm run build:package' and commit the output files." >&2
             # Run `git diff` for each line/file in $CHANGED_FILES:
             echo "$CHANGED_FILES" | xargs -I {} git diff --ignore-space-at-eol --text -- {}
             exit 1
+          else
+            echo "✅ No uncommitted changes detected after build."
           fi
         id: diff
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           CHANGED_FILES=$(git diff --ignore-space-at-eol --name-only dist/ | grep -vE "$FILES_TO_IGNORE")
           if [ -n "$CHANGED_FILES" ]; then
-            echo "❗️ Detected uncommitted changes after build (see diff output below)." >&2
-            echo "This indicates that the dist/ directory is out of sync with the checked-in index.js." >&2
-            echo "⭐️ If the changes below are expected, run 'npm run build:compile && npm run build:package' and commit the output files." >&2
+            echo "\n❗️ Detected uncommitted changes after build (see diff output below)." >&2
+            echo "This indicates that the dist/ directory is out of sync with the checked-in index.js.\n" >&2
+            echo "⭐️ If the changes below are expected, run 'npm run build:compile && npm run build:package' and commit the output files.\n" >&2
             # Run `git diff` for each line/file in $CHANGED_FILES:
             echo "$CHANGED_FILES" | xargs -I {} git diff --ignore-space-at-eol --text -- {}
             exit 1


### PR DESCRIPTION
This improves the error output when the `dist` directory contents do not match what was committed.

- Adds the `--text` argument to `git diff`, which allows binary-like files like index.js to actually be rendered with full output, so you can see what changed in the CI output.
- Adds the `FILES_TO_IGNORE` variable, so we can specify files that we don't care to diff.
- Adds some helpful error output which should make it more clear what the error means and what to do.

Example error output:
<img width="1448" alt="image" src="https://github.com/actions/add-to-project/assets/1514176/d444502b-430a-48a9-bfb3-40a3c41e246b">

Example success output:
<img width="773" alt="image" src="https://github.com/actions/add-to-project/assets/1514176/6db8869b-a2a8-4781-bf92-ccb4fa18ab74">
