### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -4,6 +4,8 @@
 # For our project, we generate this file through a build process from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/actions/add-to-project/security/code-scanning/6](https://github.com/actions/add-to-project/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The minimal required permission for this workflow is `contents: read`, since it does not need to write to the repository or perform privileged actions. The `permissions` block should be added at the root level (above `jobs:`) to apply to all jobs in the workflow. No changes to the steps or logic are required. Only the YAML file `.github/workflows/check-dist.yml` needs to be edited, with the new block inserted after the `name:` field and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
