### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: Licensed
 permissions:
   contents: read

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Licensed
 
 on:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Licensed
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/actions/add-to-project/security/code-scanning/5](https://github.com/actions/add-to-project/security/code-scanning/5)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the minimum required privileges. Since the workflow only checks out code, installs dependencies, and runs a license check, it does not need write access to repository contents or other resources. The minimal required permission is `contents: read`. This block can be added at the root level (recommended for single-job workflows) or at the job level. In this case, adding it at the root level (just after the `name:` and before `on:`) will apply the restriction to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
