### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: 'build-test'
+permissions:
+  contents: read
 on: # rebuild any PRs and main branch changes
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 'build-test'
 on: # rebuild any PRs and main branch changes
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: 'build-test'
 permissions:
   contents: read


### PR DESCRIPTION
Potential fix for [https://github.com/actions/add-to-project/security/code-scanning/7](https://github.com/actions/add-to-project/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to check out code but does not allow it to make changes to the repository. You should insert the following block after the `name:` line and before the `on:` block in `.github/workflows/test.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
