### PR TITLE
use node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in the release GitHub Actions workflow from version 20 to version 24. This ensures that the workflow runs with the latest Node.js features and security updates.