### PR TITLE
docs(action): add missing defaults and fix itemId output description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Add To GitHub projects
-description: Automatically add issues and PRs to GitHub projects
+description: Automatically add issues and pull requests to GitHub projects
 author: GitHub
 branding:
   icon: table
@@ -13,13 +13,18 @@ inputs:
     description: A GitHub personal access token with write access to the project
   labeled:
     required: false
+    default: ''
     description: A comma-separated list of labels to use as a filter for issue to be added
   label-operator:
     required: false
+    default: 'OR'
     description: The behavior of the labels filter, AND to match all labels, OR to match any label, NOT to exclude any listed label (default is OR)
 outputs:
   itemId:
-    description: The ID of the item that was added to the project
+    description: >-
+      The node ID of the project item that was added. If the issue or pull request
+      belongs to a different owner than the project, a draft issue is created and
+      this is the ID of that draft item.
 runs:
   using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
Fixes three inaccuracies in `action.yml` where the metadata diverged from the actual implementation.

## Changes
- **`labeled`**: added `default: ''` — reflects `core.getInput('labeled')` returning an empty string when not provided
- **`label-operator`**: added `default: 'OR'` — reflects the `else` branch in the implementation, which applies OR semantics when the input is empty or unset
- **`itemId` output**: replaced vague description with one that documents both code paths: linked project item (same owner) and draft issue (cross-owner fallback)
- **Top-level `description`**: expanded abbreviation "PRs" → "pull requests" for consistency

## Motivation
The `labeled` and `label-operator` inputs had no `default:` fields, so tooling (e.g. the Actions marketplace, editor extensions) could not surface defaults to users without reading the source. The `itemId` description was 
misleading for the cross-owner case, where the action silently creates a draft issue rather than linking the original item.

## Impact
- No behavior change — defaults match what the code already does
- Fully backward compatible — no input/output names, types, or `required` flags changed
- Editors and the Actions marketplace will now display accurate defaults for both optional inputs

## Testing
`action.yml` is metadata-only. Changes verified by inspecting the diff against the implementation in `src/add-to-project.ts`.