### PR TITLE
Bump `js-yaml` to 4.3.1 and 3.15.1 to address GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1203,9 +1203,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7950,9 +7950,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     },
     "@actions/http-client": {
       "undici": "^6.27.0"
+    },
+    "js-yaml": "^4.3.1",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.1"
     }
   },
   "engines": {


### PR DESCRIPTION
## Summary

Bumps the transitive `js-yaml` dependency to patched versions to address [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj).

The advisory affects both major lines of `js-yaml`, and this project resolves both:

| Path | Required range | Before | After |
| --- | --- | --- | --- |
| `@eslint/eslintrc`, `cosmiconfig` | `^4.1.1` / `^4.1.0` | 4.2.0 | **4.3.1** |
| `@istanbuljs/load-nyc-config` (via `babel-plugin-istanbul`) | `^3.13.1` | 3.15.0 | **3.15.1** |

## Why `overrides` rather than a plain update

`js-yaml` is not a direct dependency, and the two paths above require different major versions. Left to its own devices, npm proposed satisfying the constraint by **downgrading `jest` from 30.4.2 to 25.0.0**, which is a much larger regression than the issue being fixed. Path-scoped `overrides` pin each copy to its patched version while leaving the rest of the tree alone.

The nested override for `@istanbuljs/load-nyc-config` is intentional. A single blanket `js-yaml` override would force 4.x into that path, and `js-yaml` 4.x removed `safeLoad`, which `load-nyc-config` calls.

No production code changes. Both copies of `js-yaml` are dev-only.