### PR TITLE
tests: cover codepath in which a non-duplicate API error is encountered

### DIFF
--- a/__tests__/add-to-project.test.ts
+++ b/__tests__/add-to-project.test.ts
@@ -658,6 +658,92 @@ describe('addToProject', () => {
     expect(gqlMock).not.toHaveBeenCalled()
   })
 
+  test(`throws an error when unable to add the item to a project by id`, async () => {
+    mockGetInput({
+      'project-url': 'https://github.com/orgs/actions/projects/1',
+      'github-token': 'gh_token',
+    })
+
+    github.context.payload = {
+      issue: {
+        number: 1,
+        labels: [],
+        // eslint-disable-next-line camelcase
+        html_url: 'https://github.com/actions/add-to-project/issues/74',
+      },
+      repository: {
+        name: 'add-to-project',
+        owner: {
+          login: 'actions',
+        },
+      },
+    }
+
+    const infoSpy = jest.spyOn(core, 'info')
+    const gqlMock = mockGraphQL(
+      {
+        test: /getProject/,
+        return: {
+          organization: {
+            projectV2: {
+              id: 'project-id',
+            },
+          },
+        },
+      },
+      {
+        test: /addProjectV2ItemById/,
+        return: () => Promise.reject(new Error('An unexpected error occurred')),
+      },
+    )
+    await expect(addToProject()).rejects.toThrow('An unexpected error occurred')
+    expect(infoSpy.mock.calls.length).toEqual(1)
+    expect(gqlMock.mock.calls.length).toEqual(2)
+  })
+
+  test(`throws an error when unable to add a draft item to a project`, async () => {
+    mockGetInput({
+      'project-url': 'https://github.com/orgs/actions/projects/1',
+      'github-token': 'gh_token',
+    })
+
+    github.context.payload = {
+      issue: {
+        number: 1,
+        labels: [],
+        // eslint-disable-next-line camelcase
+        html_url: 'https://github.com/actions/add-to-project/issues/74',
+      },
+      repository: {
+        name: 'add-to-project',
+        owner: {
+          login: 'not-actions',
+        },
+      },
+    }
+
+    const infoSpy = jest.spyOn(core, 'info')
+    const gqlMock = mockGraphQL(
+      {
+        test: /getProject/,
+        return: {
+          organization: {
+            projectV2: {
+              id: 'project-id',
+            },
+          },
+        },
+      },
+      {
+        test: /addProjectV2DraftIssue/,
+        return: () => Promise.reject(new Error('An unexpected error occurred')),
+      },
+    )
+    await expect(addToProject()).rejects.toThrow('An unexpected error occurred')
+    expect(infoSpy.mock.calls.length).toEqual(1)
+    expect(gqlMock.mock.calls.length).toEqual(2)
+  })
+
   test(`works with URLs that are not under the github.com domain`, async () => {
     github.context.payload = {
       issue: {

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
     description: >-
       The node ID of the project item that was added. If the issue or pull request
       belongs to a different owner than the project, a draft issue is created and
-      this is the ID of that draft item.
+      this is the ID of that draft item. This value will be empty if the item was already present in the project.
 runs:
   using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
as suggested in https://github.com/actions/add-to-project/pull/797#pullrequestreview-4921117891